### PR TITLE
Allow NON-TRANSFERABLE Day Pass tickets on any day

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Before allowing check-in, the extension verifies:
 - For non-transferable badges, the **name on the badge matches** the person presenting
 - The attendee's **emergency contact information** is filled in
 - For Adult and Teen tickets, the volunteer is reminded to **verify age**
-- For Day Pass tickets, the pass is being used on the **correct day**
+- For Day Pass tickets, the pass is being used on the **correct day** (tickets with "NON-TRANSFERABLE" in the name are valid any day)
 
 It also gives the volunteer two visual cues:
 

--- a/config.js
+++ b/config.js
@@ -88,6 +88,9 @@ const CONFIG = {
   // Used to validate Day Pass tickets — must be used on the correct day.
   // Keys must match exactly how the day appears in the Neon ticket name.
   // Values: JS getDay() numbers — 0=Sun, 1=Mon, 4=Thu, 5=Fri, 6=Sat
+  // EXCEPTION: a Day Pass ticket name containing "NON-TRANSFERABLE" (any
+  // case) is valid any day and skips this check — see validateDayPass()
+  // in js/registrations.js.
   conDays: {
     "Thursday": 4,
     "Friday":   5,

--- a/js/registrations.js
+++ b/js/registrations.js
@@ -668,9 +668,13 @@ function resolveTicketConfig(ticketTypeName) {
 /**
  * Validates that a day pass is being used on the correct day of the week.
  * E.g., a "Friday" pass can only be used on Fridays.
+ * NON-TRANSFERABLE Day Passes are valid any day and skip the day check.
  * Returns { valid: boolean }
  */
 function validateDayPass(ticketTypeName) {
+  if (ticketTypeName.toUpperCase().includes("NON-TRANSFERABLE")) {
+    return { valid: true };
+  }
   const dayName = Object.keys(CONFIG.conDays).find(d => ticketTypeName.includes(d));
   if (!dayName || new Date().getDay() !== CONFIG.conDays[dayName]) {
     return { valid: false };

--- a/tests/fixtures/attendees.yaml
+++ b/tests/fixtures/attendees.yaml
@@ -126,6 +126,18 @@
     state: red
     conditions: [incorrectDay]
 
+# ── GREEN: non-transferable day pass, any day ────────────────────────────────
+- name: green-nontransferable-day-pass
+  # Setup: a Day Pass ticket whose name includes "NON-TRANSFERABLE" (e.g.
+  # "Adult Thursday Day Pass NON-TRANSFERABLE") tested on a day other than
+  # the day named in the ticket. Should NOT trigger incorrectDay.
+  page: attendeeEdit
+  accountId: ""
+  attendeeId: ""
+  expect:
+    state: green
+    conditions: []
+
 # ── RED: unknown ticket type ─────────────────────────────────────────────────
 - name: red-unknown-ticket
   # Setup: a ticket whose name does NOT include any of: Adult, Teen, Youth,


### PR DESCRIPTION
## Summary
- Day Pass tickets are normally blocked (INCORRECT DAY) unless used on the weekday named in the ticket
- A Day Pass ticket name containing "NON-TRANSFERABLE" (case-insensitive) now skips the day check and is valid any day
- Updated `config.js` comment, `README.md`, and added a `green-nontransferable-day-pass` fixture placeholder in `tests/fixtures/attendees.yaml`

## Test plan
- [ ] Fill in `accountId`/`attendeeId` on the `green-nontransferable-day-pass` fixture in `tests/fixtures/attendees.yaml` using a training-event NON-TRANSFERABLE Day Pass attendee
- [ ] `npm test` and confirm the fixture passes (green, no `incorrectDay` condition) on a day other than the one named in the ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)